### PR TITLE
Add option to disable verification footer on document pages to SealSpec

### DIFF
--- a/src/AddVerificationPages.java
+++ b/src/AddVerificationPages.java
@@ -442,7 +442,7 @@ public class AddVerificationPages extends Engine {
                     }
                 }
             }
-            if(!spec.preseal) {
+            if(!spec.preseal && !spec.disableFooter) {
                 addPaginationFooter(spec, stamper, canvas, cropBox,
                         spec.documentNumberText, spec.initialsText);
             }

--- a/src/SealSpec.java
+++ b/src/SealSpec.java
@@ -193,6 +193,7 @@ class SealSpec {
     public ArrayList<Field> fields;
     public ArrayList<String> fonts;
     public String background;
+    public Boolean disableFooter;
 
     static public SealSpec FromJSON(InputStream specFile) throws IOException, JSONException {
         StringWriter writer = new StringWriter();
@@ -211,6 +212,7 @@ class SealSpec {
         spec.initialsText = obj.optString("initialsText");
         // spec.hostpart = obj.getString("hostpart");
         spec.background = obj.optString("background", null);
+        spec.disableFooter = obj.optBoolean("disableFooter", false);
 
         JSONArray arr = obj.optJSONArray("filesList");
         spec.filesList = new ArrayList<FileDesc>();

--- a/test/seal-simplest-verified.json
+++ b/test/seal-simplest-verified.json
@@ -2,6 +2,7 @@
  "output": "test/results/seal-simplest-verified.pdf",
  "preseal": false,
  "documentNumberText": "Transaction 0000001234",
+ "disableFooter": true,
  "persons": [{"fullname": "Full Name X",
               "company": "Company Name",
               "personalnumber": "Personal Number",


### PR DESCRIPTION
Please see https://github.com/scrive/kontrakcja/pull/314

We need confirmation form Axel that we should only remove document pages footer, as this PR leaves it for attachment pages.
