### PR TITLE
Added underCanvas and placed highlighting there.

### DIFF
--- a/src/AddVerificationPages.java
+++ b/src/AddVerificationPages.java
@@ -378,7 +378,8 @@ public class AddVerificationPages extends Engine {
                 }
             }
 
-            PdfContentByte canvas = stamper.getOverContent(i);
+            PdfContentByte overCanvas = stamper.getOverContent(i);
+            PdfContentByte underCanvas = stamper.getUnderContent(i);
             for( Field field : fields ) {
                 if(field.page==i && !field.onlyForSummary) {
 
@@ -412,7 +413,7 @@ public class AddVerificationPages extends Engine {
                         float realx = field.x * cropBox.getWidth() + cropBox.getLeft() - fontOffset;
                         float realy = (1 - field.y) * cropBox.getHeight() + cropBox.getBottom() - fontBaseline;
 
-                        ColumnText.showTextAligned(canvas, Element.ALIGN_LEFT,
+                        ColumnText.showTextAligned(overCanvas, Element.ALIGN_LEFT,
                                                    para,
                                                    realx, realy,
                                                    0);
@@ -442,7 +443,7 @@ public class AddVerificationPages extends Engine {
                         image.scaleAbsolute(flip_xy ? absoluteHeight : absoluteWidth,
                                             flip_xy ? absoluteWidth : absoluteHeight);
 
-                        canvas.addImage(image);
+                        overCanvas.addImage(image);
                     }
                 }
             }
@@ -469,7 +470,7 @@ public class AddVerificationPages extends Engine {
                     image.scaleAbsolute(flip_xy ? absoluteHeight : absoluteWidth,
                                         flip_xy ? absoluteWidth : absoluteHeight);
 
-                    canvas.addImage(image);
+                    underCanvas.addImage(image);
                 }
             }
 
@@ -477,7 +478,7 @@ public class AddVerificationPages extends Engine {
 
 
             if(!spec.preseal && !spec.disableFooter) {
-                addPaginationFooter(spec, stamper, canvas, cropBox,
+                addPaginationFooter(spec, stamper, overCanvas, cropBox,
                         spec.documentNumberText, spec.initialsText);
             }
         }


### PR DESCRIPTION
... Renamed canvas to overCanvas for avoidance of confusion.

This PR just fetches a canvas for the layer beneath the text in a pdf and puts any highlighting there instead of in the layer above the text. Other images added to the PDF still go in the top layer. The purpose is to make it so that the alpha channel in the highlighting does not bleach the text it is above, which manifested as erasing text on some printers. Tested on-screen and on the office printer and it works nicely.

The surrounding code should also be refactored at some point. This is just a minimal change to fix the problem.

@axeltalmet has requested this to be put in production, which is why I am opening this PR.